### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -2,3 +2,4 @@
 skip-check:
   - CKV_GHA_7
   - CKV2_GHA_1
+  - "CKV_SECRET_4:.*specifications/api/.*\\.json$"

--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -29,6 +29,9 @@
     "zizmor.yaml",
     ".shellcheckrc",
     ".codespellrc",
+    ".prettierignore",
+    ".trivyignore",
+    "ruff.toml",
     ".claude/settings.json",
     ".claude/governance.json",
     ".claude/hooks/protect-managed-files.sh"

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = *.json,*/tools/generated/*,vendor/*
-ignore-words-list = aks,datas,hcl,iterm,uncomplete,ves
+ignore-words-list = afterall,aks,datas,edn,hcl,ists,iterm,nd,preceeding,uncomplete,ves

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,5 +15,8 @@ indent_size = unset
 [*.mdx]
 indent_size = unset
 
+[*.py]
+indent_size = 4
+
 [Makefile]
 indent_style = tab

--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,4 +1,7 @@
 {
-  "Exclude": ["\\.md$", "\\.mdx$"],
-  "DisableIndentSize": true
+  "Disable": {
+    "IndentSize": true,
+    "Indentation": true
+  },
+  "Exclude": ["[.]md$", "[.]mdx$"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ projects/
 .claude/settings.local.json
 .claude/todos/
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 .playwright-mcp/
 .serena/
 .auto-claude/
@@ -99,6 +100,38 @@ claudedocs/
 cache/
 src/generated/
 out/
+
+# Bun
+*.bun-build
+
+# OpenCode plugin
+.sisyphus/*
+!.sisyphus/rules/
+packages/*/bin/
+test-injection/
+notepad.md
+oauth-success.html
+.omx/
+
+# Lock file preferences (Bun-based repos)
+package-lock.json
+yarn.lock
+
+# Monorepo build
+.turbo/
+ts-dist/
+target/
+.sst/
+tsconfig.tsbuildinfo
+
+# Nix
+.direnv/
+/result
+
+# Workspace
+.worktrees/
+.codex/
+playground/
 
 # Documentation build artifacts
 docs/_data/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+# Auto-generated files -- do not reformat
+**/src/gen/
+**/src/v2/gen/
+**/src/generated/
+**/*.gen.ts
+**/*.gen.js
+**/*.gen.d.ts

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,5 @@
+line-length = 88
+
+[format]
+quote-style = "double"
+indent-style = "space"

--- a/.textlintrc
+++ b/.textlintrc
@@ -5,7 +5,9 @@
       "exclude": [
         "repo\\b",
         "bug[- ]fix(es)?",
-        "build system(s)?"
+        "build system(s)?",
+        "readme(s)?",
+        "to-?do(s)?(?=[ ,.])"
       ]
     }
   }

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,15 @@
+# Governance-managed Trivy ignore list
+# Review quarterly — remove entries when upstream fixes are released
+#
+# Format: one CVE/ID per line
+# Lines starting with # are comments
+
+# CVE-2026-4539 — Low severity (CVSS 3.3) ReDoS in pygments AdlLexer
+# Transitive dependency: rich -> pygments
+# Affected: pygments <= 2.19.2 — no fix released to PyPI
+# Fix merged upstream: pygments/pygments#3064 (2026-03-25)
+# Pygments maintainers dispute this as a security issue per their security policy
+# Impact: Zero — AdlLexer handles openEHR archetype definitions, unused in this context
+# Expiry: 2026-05-31 — re-evaluate after pygments releases fix
+# Ref: https://nvd.nist.gov/vuln/detail/CVE-2026-4539
+CVE-2026-4539

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "formatter": {
     "indentStyle": "space",
     "indentWidth": 2,

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,5 @@
+line-length = 88
+
+[format]
+quote-style = "double"
+indent-style = "space"


### PR DESCRIPTION
Closes #169

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .editorconfig
- .gitignore
- biome.json
- .textlintrc
- .editorconfig-checker.json
- .checkov.yaml
- .codespellrc
- .prettierignore
- .trivyignore
- .ruff.toml
- ruff.toml
- .claude/governance.json