### PR TITLE
docs: add frontmatter description for llms.txt hierarchy

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: API Security
+description: API discovery, protection, and security policies for F5 Distributed Cloud.
 hero:
   tagline: API discovery, protection, and security policies.
   image:


### PR DESCRIPTION
## Summary

Refs f5xc-salesdemos/xcsh#223

Step 5c of the cascading llms.txt knowledge hierarchy -- adds a `description:` field to the index page frontmatter so the starlight-llms-txt plugin can include it in the llms.txt output.

Closes #232

## Test plan

- [ ] CI checks pass
- [ ] Verify `description:` field is present in `docs/index.mdx` frontmatter
- [ ] Verify starlight-llms-txt plugin picks up the description in build output