### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/workflows/translation-audit.yml
+++ b/.github/workflows/translation-audit.yml
@@ -1,0 +1,18 @@
+---
+# Managed by docs-control. Verifies that translations stay fresh when
+# English docs change. Generation happens in pre-commit (docs-translate
+# --staged); this gate only audits sourceHash freshness (no API calls).
+name: Translation Audit
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    # Read-only freshness audit — no secrets required.
+    uses: f5xc-salesdemos/docs-control/.github/workflows/translation-audit.yml@main

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ projects/
 .claude/todos/
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+.remember/
 .playwright-mcp/
 .serena/
 .auto-claude/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -184,6 +184,26 @@ repos:
         language: system
         pass_filenames: false
 
+  # ===========================================================================
+  # Translation generation — regenerate locale docs when English changes.
+  # Runs docs-translate --staged (docs-theme) for staged docs/en/*.mdx, which
+  # needs ANTHROPIC_API_KEY and the docs-theme toolchain. No-ops gracefully
+  # when either is unavailable; the required CI translation-audit verifies
+  # freshness regardless. Generation is intentionally local, never in CI.
+  # ===========================================================================
+  - repo: local
+    hooks:
+      - id: docs-translate
+        name: "i18n: regenerate translations for staged English docs"
+        entry: >-
+          bash -c
+          'if command -v docs-translate >/dev/null 2>&1 && [ -n "${ANTHROPIC_API_KEY:-}" ];
+          then docs-translate --staged;
+          else echo "[i18n] docs-translate/ANTHROPIC_API_KEY unavailable — skipping; CI translation-audit will verify freshness."; fi'
+        language: system
+        files: ^docs/en/.*\.mdx?$
+        pass_filenames: false
+
 ci:
   autofix_prs: true
   autoupdate_schedule: weekly
@@ -204,3 +224,4 @@ ci:
     - zizmor
     - checkov
     - gitleaks
+    - docs-translate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,5 +10,8 @@ A hook blocks direct edits — open an issue in docs-control instead.
 - The `main` branch is protected — never commit or push directly to it.
 - Create a feature branch, commit there, and open a pull request.
 - Every pull request must reference a GitHub issue (CI enforces this).
+- **Perform all git operations directly.** Do not delegate git commits,
+  pushes, or pull requests to subagents. Run `git`, `gh`, and CLI
+  commands yourself.
 
 See `CONTRIBUTING.md` for project rules.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,8 @@ If you are Claude Code, Copilot, or another AI coding assistant, follow these ru
 2. **Always work on a feature branch.** Never commit directly to `main`.
 3. **Always link the PR to the issue.** Use `Closes #N` in the PR description.
 4. **Use the `/ship` skill** when available — it handles the full Issue → Branch → PR flow.
-5. **Never force push** or attempt to bypass branch protection.
-6. **Fill out the PR template checklist** completely.
-7. **Follow the branch naming convention**: `feature/<issue>-desc`, `fix/<issue>-desc`, `docs/<issue>-desc`.
-8. **Respect CODEOWNERS** — Review the CODEOWNERS file for the default reviewer.
+5. **Perform git operations directly.** Run `git commit`, `git push`, and `gh pr create` yourself. Do not delegate to subagents.
+6. **Never force push** or attempt to bypass branch protection.
+7. **Fill out the PR template checklist** completely.
+8. **Follow the branch naming convention**: `feature/<issue>-desc`, `fix/<issue>-desc`, `docs/<issue>-desc`.
+9. **Respect CODEOWNERS** — Review the CODEOWNERS file for the default reviewer.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+🌐 English |
+[日本語](https://f5xc-salesdemos.github.io/api-protection/ja/) |
+[한국어](https://f5xc-salesdemos.github.io/api-protection/ko/) |
+[简体中文](https://f5xc-salesdemos.github.io/api-protection/zh-cn/) |
+[繁體中文](https://f5xc-salesdemos.github.io/api-protection/zh-tw/) |
+[Español](https://f5xc-salesdemos.github.io/api-protection/es/) |
+[Português](https://f5xc-salesdemos.github.io/api-protection/pt-br/) |
+[Français](https://f5xc-salesdemos.github.io/api-protection/fr/) |
+[Deutsch](https://f5xc-salesdemos.github.io/api-protection/de/) |
+[Italiano](https://f5xc-salesdemos.github.io/api-protection/it/) |
+[العربية](https://f5xc-salesdemos.github.io/api-protection/ar/) |
+[हिन्दी](https://f5xc-salesdemos.github.io/api-protection/hi/) |
+[ไทย](https://f5xc-salesdemos.github.io/api-protection/th/)
+
 # API Security
 
 [![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/api-protection/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/api-protection/actions/workflows/github-pages-deploy.yml)

--- a/biome.json
+++ b/biome.json
@@ -26,7 +26,14 @@
   },
   "overrides": [
     {
-      "includes": ["dist/**", "build/**", "release/**", "vendor/**"],
+      "includes": [
+        "dist/**",
+        "build/**",
+        "release/**",
+        "vendor/**",
+        "docs/snapshots/**",
+        ".github/config/managed-files-manifest.json"
+      ],
       "formatter": {
         "enabled": false
       },


### PR DESCRIPTION
Closes #456

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .github/workflows/translation-audit.yml
- CONTRIBUTING.md
- CLAUDE.md
- .gitignore
- .pre-commit-config.yaml
- biome.json
- README.md